### PR TITLE
No longer remove illegal args. Instead warn the user they are using a…

### DIFF
--- a/cobalt.go
+++ b/cobalt.go
@@ -3,11 +3,12 @@ package hpc
 import (
 	"bytes"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type CobaltJob struct {
@@ -60,7 +61,7 @@ func (j CobaltJob) New(job *Job) (error, CobaltJob) {
 	if len(job.NativeSpecs) != 0 {
 		//Defines an array of illegal arguments which will not be passed in as native specifications
 		illegalArguments := []string{"-o", "-e", "--debuglog", " "}
-		Specs = RemoveIllegalParams(job.NativeSpecs, illegalArguments)
+		j.Job.CheckIllegalParams(job.NativeSpecs, illegalArguments)
 	}
 
 	//If native specs were defined attach them to the end. Assemble bash command

--- a/lsf.go
+++ b/lsf.go
@@ -3,9 +3,10 @@ package hpc
 import (
 	"bufio"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type LSFJob struct {
@@ -31,8 +32,11 @@ func (j LSFJob) New(job *Job) (error, LSFJob) {
 	var Specs []string
 	if len(job.NativeSpecs) != 0 {
 		//Defines an array of illegal arguments which will not be passed in as native specifications
-		illegalArguments := []string{"-e", "-o", "-eo", " "}
-		Specs = RemoveIllegalParams(job.NativeSpecs, illegalArguments)
+		illegalArguments := []string{"-e", "-o", "-eo"}
+		warnings := job.CheckIllegalParams(job.NativeSpecs, illegalArguments)
+		for i, _ := range warnings {
+			job.PrintWarning(warnings[i])
+		}
 	}
 
 	if len(Specs) != 0 {
@@ -54,7 +58,7 @@ func (j *LSFJob) RunJob() (err error, out string) {
 		log.WithFields(log.Fields{
 			"error": err,
 		}).Warn("Error creating stdout pipe")
-		j.PrintToParent("Error creating stdout pipe")
+		j.Job.PrintToParent("Error creating stdout pipe")
 		return
 	}
 

--- a/slurm.go
+++ b/slurm.go
@@ -2,11 +2,12 @@ package hpc
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type SlurmJob struct {
@@ -43,8 +44,8 @@ func (j SlurmJob) New(job *Job) (error, SlurmJob) {
 	var Specs []string
 	if len(job.NativeSpecs) != 0 {
 		//Defines an array of illegal arguments which will not be passed in as native specifications
-		illegalArguments := []string{" "}
-		Specs = RemoveIllegalParams(job.NativeSpecs, illegalArguments)
+		illegalArguments := []string{"-o", "--output"}
+		j.Job.CheckIllegalParams(job.NativeSpecs, illegalArguments)
 	}
 
 	if len(job.NativeSpecs) != 0 {


### PR DESCRIPTION
…n illegal argument.

Adds print warning func to Job struct.